### PR TITLE
Fix callback transformer implementation

### DIFF
--- a/src/FastNorth/PropertyMapper/Transformer/Callback.php
+++ b/src/FastNorth/PropertyMapper/Transformer/Callback.php
@@ -38,9 +38,9 @@ class Callback implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function forward($value, $context)
+    public function transform($value, $context)
     {
-        return call_user_method_array($this->transform, [$value, $context]);
+        return call_user_func($this->transform, $value, $context);
     }
 
     /**
@@ -48,6 +48,6 @@ class Callback implements TransformerInterface
      */
     public function reverse($value, $context)
     {
-        return call_user_method_array($this->reverse, [$value, $context]);
+        return call_user_func($this->reverse, $value, $context);
     }
 }


### PR DESCRIPTION
Fixes the `Callback` implementation of `TransformerInterface` and adds PHP7 support by removing the call to the deprecated `call_user_method_array` function.

**BC Break?** No

**Changes:**
- Replace deprecated function call (Fixes #1)
- Ensure callback transformer honors TransformerInterface (Fixes #2)
