### PR TITLE
Add a default value parameter to the `map` method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 
 install:
   - composer install

--- a/src/FastNorth/PropertyMapper/Map.php
+++ b/src/FastNorth/PropertyMapper/Map.php
@@ -38,9 +38,9 @@ class Map implements MapInterface
     /**
      * @inheritDoc
      */
-    public function map($from, $to, TransformerInterface $transformer = null)
+    public function map($from, $to, TransformerInterface $transformer = null, $default = null)
     {
-        $this->links[] = new Link($from, $to, $transformer);
+        $this->links[] = new Link($from, $to, $transformer, $default);
 
         return $this;
     }

--- a/src/FastNorth/PropertyMapper/Map.php
+++ b/src/FastNorth/PropertyMapper/Map.php
@@ -2,10 +2,10 @@
 
 namespace FastNorth\PropertyMapper;
 
-use FastNorth\PropertyMapper\Transformer\TransformerInterface;
-use FastNorth\PropertyMapper\Map\Link;
 use FastNorth\PropertyMapper\Map\Embedded;
 use FastNorth\PropertyMapper\Map\EmbeddedCollection;
+use FastNorth\PropertyMapper\Map\Link;
+use FastNorth\PropertyMapper\Transformer\TransformerInterface;
 
 /**
  * Map
@@ -24,14 +24,14 @@ class Map implements MapInterface
     /**
      * Embeds
      *
-     * @var Embedded
+     * @var Embedded[]
      */
     private $embeds = [];
 
     /**
      * Embedded collections
      *
-     * @var MappedCollection[]
+     * @var EmbeddedCollection[]
      */
     private $embeddedCollections = [];
 

--- a/src/FastNorth/PropertyMapper/Map/AbstractLink.php
+++ b/src/FastNorth/PropertyMapper/Map/AbstractLink.php
@@ -24,16 +24,23 @@ class AbstractLink implements LinkedInterface
     private $to;
 
     /**
+     * @var mixed
+     */
+    private $default;
+
+    /**
      * Constructor
      *
      * @param string $from
      * @param string $to
+     * @param mixed  $default
      */
-    public function __construct($from, $to)
+    public function __construct($from, $to, $default = null)
     {
         $this
             ->setFrom($from)
-            ->setTo($to);
+            ->setTo($to)
+            ->setDefault($default);
     }
 
     /**
@@ -78,6 +85,30 @@ class AbstractLink implements LinkedInterface
     public function setTo($to)
     {
         $this->to = $to;
+
+        return $this;
+    }
+
+    /**
+     * Get the default value if no link was found
+     *
+     * @return mixed
+     */
+    public function getDefault()
+    {
+        return $this->default;
+    }
+
+    /**
+     * Set the default value
+     *
+     * @param    $default
+     *
+     * @return self
+     */
+    public function setDefault($default)
+    {
+        $this->default = $default;
 
         return $this;
     }

--- a/src/FastNorth/PropertyMapper/Map/AbstractLink.php
+++ b/src/FastNorth/PropertyMapper/Map/AbstractLink.php
@@ -19,7 +19,7 @@ class AbstractLink implements LinkedInterface
     /**
      * The to endpoint
      *
-     * @var to
+     * @var string
      */
     private $to;
 
@@ -56,7 +56,8 @@ class AbstractLink implements LinkedInterface
     /**
      * Set the from endpoint
      *
-     * @param  string   $from
+     * @param  string $from
+     *
      * @return self
      */
     public function setFrom($from)
@@ -69,7 +70,7 @@ class AbstractLink implements LinkedInterface
     /**
      * Get the to endpoint
      *
-     * @return to
+     * @return string
      */
     public function getTo()
     {
@@ -79,7 +80,8 @@ class AbstractLink implements LinkedInterface
     /**
      * Set the to endpoint
      *
-     * @param  to   $to
+     * @param string $to
+     *
      * @return self
      */
     public function setTo($to)
@@ -113,4 +115,3 @@ class AbstractLink implements LinkedInterface
         return $this;
     }
 }
-

--- a/src/FastNorth/PropertyMapper/Map/Embedded.php
+++ b/src/FastNorth/PropertyMapper/Map/Embedded.php
@@ -2,8 +2,8 @@
 
 namespace FastNorth\PropertyMapper\Map;
 
-use FastNorth\PropertyMapper\MapInterface;
 use FastNorth\PropertyMapper\FactoryInterface;
+use FastNorth\PropertyMapper\MapInterface;
 
 /**
  * Embedded.

--- a/src/FastNorth/PropertyMapper/Map/EmbeddedCollection.php
+++ b/src/FastNorth/PropertyMapper/Map/EmbeddedCollection.php
@@ -2,8 +2,8 @@
 
 namespace FastNorth\PropertyMapper\Map;
 
-use FastNorth\PropertyMapper\MapInterface;
 use FastNorth\PropertyMapper\FactoryInterface;
+use FastNorth\PropertyMapper\MapInterface;
 
 /**
  * EmbeddedCollection
@@ -29,9 +29,9 @@ class EmbeddedCollection extends AbstractLink implements EmbeddedCollectionInter
     /**
      * Constructor
      *
-     * @param string $from
-     * @param string $to
-     * @param MapInterface $map
+     * @param string           $from
+     * @param string           $to
+     * @param MapInterface     $map
      * @param FactoryInterface $factory
      */
     public function __construct($from, $to, MapInterface $map, FactoryInterface $factory)
@@ -58,4 +58,3 @@ class EmbeddedCollection extends AbstractLink implements EmbeddedCollectionInter
         return $this->factory;
     }
 }
-

--- a/src/FastNorth/PropertyMapper/Map/EmbeddedCollectionInterface.php
+++ b/src/FastNorth/PropertyMapper/Map/EmbeddedCollectionInterface.php
@@ -2,8 +2,8 @@
 
 namespace FastNorth\PropertyMapper\Map;
 
-use FastNorth\PropertyMapper\MapInterface;
 use FastNorth\PropertyMapper\FactoryInterface;
+use FastNorth\PropertyMapper\MapInterface;
 
 /**
  * EmbeddedCollectionInterface
@@ -14,6 +14,8 @@ interface EmbeddedCollectionInterface extends LinkedInterface
 {
     /**
      * Get the map for the collection
+     *
+     * @return MapInterface
      */
     public function getMap();
 

--- a/src/FastNorth/PropertyMapper/Map/EmbeddedInterface.php
+++ b/src/FastNorth/PropertyMapper/Map/EmbeddedInterface.php
@@ -2,8 +2,8 @@
 
 namespace FastNorth\PropertyMapper\Map;
 
-use FastNorth\PropertyMapper\MapInterface;
 use FastNorth\PropertyMapper\FactoryInterface;
+use FastNorth\PropertyMapper\MapInterface;
 
 /**
  * EmbeddedInterface

--- a/src/FastNorth/PropertyMapper/Map/Link.php
+++ b/src/FastNorth/PropertyMapper/Map/Link.php
@@ -21,14 +21,14 @@ class Link extends AbstractLink implements LinkInterface
     /**
      * Constructor
      *
-     * @param string $from
-     * @param string $to
-     *
+     * @param string               $from
+     * @param string               $to
      * @param TransformerInterface $transformer optional transformer
+     * @param mixed                $default
      */
-    public function __construct($from, $to, TransformerInterface $transformer = null)
+    public function __construct($from, $to, TransformerInterface $transformer = null, $default = null)
     {
-        parent::__construct($from, $to);
+        parent::__construct($from, $to, $default);
 
         if ($transformer instanceof TransformerInterface) {
             $this->setTransformer($transformer);

--- a/src/FastNorth/PropertyMapper/Map/Link.php
+++ b/src/FastNorth/PropertyMapper/Map/Link.php
@@ -58,7 +58,8 @@ class Link extends AbstractLink implements LinkInterface
     /**
      * Set the transformer
      *
-     * @param  TransformerInterface   $transformer
+     * @param  TransformerInterface $transformer
+     *
      * @return self
      */
     public function setTransformer(TransformerInterface $transformer)
@@ -68,4 +69,3 @@ class Link extends AbstractLink implements LinkInterface
         return $this;
     }
 }
-

--- a/src/FastNorth/PropertyMapper/Map/LinkInterface.php
+++ b/src/FastNorth/PropertyMapper/Map/LinkInterface.php
@@ -2,7 +2,7 @@
 
 namespace FastNorth\PropertyMapper\Map;
 
-use FastNorth\PropertyMapper\Transfomer\TransformerInterface;
+use FastNorth\PropertyMapper\Transformer\TransformerInterface;
 
 /**
  * LinkInterface

--- a/src/FastNorth/PropertyMapper/Map/LinkedInterface.php
+++ b/src/FastNorth/PropertyMapper/Map/LinkedInterface.php
@@ -22,4 +22,11 @@ interface LinkedInterface
      * @return string
      */
     public function getTo();
+
+    /**
+     * Get the default value if no link was found
+     *
+     * @return mixed
+     */
+    public function getDefault();
 }

--- a/src/FastNorth/PropertyMapper/MapInterface.php
+++ b/src/FastNorth/PropertyMapper/MapInterface.php
@@ -2,9 +2,10 @@
 
 namespace FastNorth\PropertyMapper;
 
-use FastNorth\PropertyMapper\Transformer\TransformerInterface;
+use FastNorth\PropertyMapper\Map\EmbeddedCollectionInterface;
+use FastNorth\PropertyMapper\Map\EmbeddedInterface;
 use FastNorth\PropertyMapper\Map\LinkInterface;
-use FastNorth\PropertyMapper\Map\MappedCollectionInterface;
+use FastNorth\PropertyMapper\Transformer\TransformerInterface;
 
 /**
  * MapInterface.
@@ -64,7 +65,7 @@ interface MapInterface
     /**
      * Get all embedded collections.
      *
-     * @return MappedCollectionInterface[]
+     * @return EmbeddedCollectionInterface[]
      */
     public function getEmbeddedCollections();
 }

--- a/src/FastNorth/PropertyMapper/Mapper.php
+++ b/src/FastNorth/PropertyMapper/Mapper.php
@@ -2,9 +2,8 @@
 
 namespace FastNorth\PropertyMapper;
 
-use FastNorth\PropertyMapper\Mapper;
-use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
  * Mapper.
@@ -30,7 +29,7 @@ class Mapper implements MapperInterface
     public function __construct(PropertyAccessorInterface $propertyAccess = null)
     {
         if (!($propertyAccess instanceof PropertyAccessorInterface)) {
-            $propertyAccess = new PropertyAccessor();
+            $propertyAccess = new PropertyAccessor(false, true);
         }
         $this->propertyAccess = $propertyAccess;
     }

--- a/src/FastNorth/PropertyMapper/Mapper.php
+++ b/src/FastNorth/PropertyMapper/Mapper.php
@@ -2,7 +2,7 @@
 
 namespace FastNorth\PropertyMapper;
 
-use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
@@ -29,7 +29,10 @@ class Mapper implements MapperInterface
     public function __construct(PropertyAccessorInterface $propertyAccess = null)
     {
         if (!($propertyAccess instanceof PropertyAccessorInterface)) {
-            $propertyAccess = new PropertyAccessor(false, true);
+            $propertyAccess = PropertyAccess::createPropertyAccessorBuilder()
+                                            ->enableExceptionOnInvalidIndex()
+                                            ->disableMagicCall()
+                                            ->getPropertyAccessor();
         }
         $this->propertyAccess = $propertyAccess;
     }

--- a/src/FastNorth/PropertyMapper/Processor/EmbeddedCollections.php
+++ b/src/FastNorth/PropertyMapper/Processor/EmbeddedCollections.php
@@ -32,7 +32,7 @@ class EmbeddedCollections extends Processor
             // Source items
             $source = $this->propertyAccess->getValue($from, $collection->getFrom());
 
-            foreach($source as $item) {
+            foreach ($source as $item) {
                 $newItem = $collection->getFactory()->factory($item);
                 $value[] = $mapper->process($item, $newItem, $collection->getMap());
             }
@@ -63,7 +63,7 @@ class EmbeddedCollections extends Processor
             // Source items
             $source = $this->propertyAccess->getValue($to, $collection->getTo());
 
-            foreach($source as $item) {
+            foreach ($source as $item) {
                 $newItem = $collection->getFactory()->reverse($item);
                 $value[] = $mapper->reverse($newItem, $item, $collection->getMap());
             }
@@ -74,4 +74,3 @@ class EmbeddedCollections extends Processor
         return $this;
     }
 }
-

--- a/src/FastNorth/PropertyMapper/Processor/Embeds.php
+++ b/src/FastNorth/PropertyMapper/Processor/Embeds.php
@@ -23,9 +23,7 @@ class Embeds extends Processor
      */
     public function process($from, &$to, MapInterface $map)
     {
-        $mapper = new Mapper;
         foreach ($map->getEmbeds() as $embed) {
-
             // Create new embedded
             $embedded = $embed->getFactory()->factory($from);
 
@@ -49,7 +47,6 @@ class Embeds extends Processor
      */
     public function reverse(&$from, $to, MapInterface $map)
     {
-        $mapper = new Mapper;
         foreach ($map->getEmbeds() as $embed) {
             // Get embedded value from $to
             $originalEmbedded = $this->propertyAccess->getValue($to, $embed->getTo());
@@ -61,4 +58,3 @@ class Embeds extends Processor
         return $this;
     }
 }
-

--- a/src/FastNorth/PropertyMapper/Processor/Links.php
+++ b/src/FastNorth/PropertyMapper/Processor/Links.php
@@ -23,13 +23,14 @@ class Links extends Processor
     public function process($from, &$to, MapInterface $map)
     {
         foreach ($map->getLinks() as $link) {
-            if ($link->hasTransformer()) {
-                $value = $link->getTransformer()->transform(
-                    $this->propertyAccess->getValue($from, $link->getFrom()),
-                    $from
-                );
-            } else {
+            if ($this->propertyAccess->isReadable($from, $link->getFrom())) {
                 $value = $this->propertyAccess->getValue($from, $link->getFrom());
+            } else {
+                $value = $link->getDefault();
+            }
+
+            if ($link->hasTransformer()) {
+                $value = $link->getTransformer()->transform($value, $from);
             }
 
             $this->propertyAccess->setValue($to, $link->getTo(), $value);
@@ -50,13 +51,14 @@ class Links extends Processor
     public function reverse(&$from, $to, MapInterface $map)
     {
         foreach ($map->getLinks() as $link) {
-            if ($link->hasTransformer()) {
-                $value = $link->getTransformer()->reverse(
-                    $this->propertyAccess->getValue($to, $link->getTo()),
-                    $to
-                );
-            } else {
+            if ($this->propertyAccess->isReadable($to, $link->getTo())) {
                 $value = $this->propertyAccess->getValue($to, $link->getTo());
+            } else {
+                $value = $link->getDefault();
+            }
+
+            if ($link->hasTransformer()) {
+                $value = $link->getTransformer()->reverse($value, $to);
             }
 
             $this->propertyAccess->setValue($from, $link->getFrom(), $value);

--- a/src/FastNorth/PropertyMapper/Processor/Links.php
+++ b/src/FastNorth/PropertyMapper/Processor/Links.php
@@ -67,4 +67,3 @@ class Links extends Processor
         return $this;
     }
 }
-

--- a/src/FastNorth/PropertyMapper/Processor/Processor.php
+++ b/src/FastNorth/PropertyMapper/Processor/Processor.php
@@ -28,4 +28,3 @@ abstract class Processor
         $this->propertyAccess = $propertyAccess;
     }
 }
-

--- a/src/FastNorth/PropertyMapper/Transformer/DateTime/StringToDateTime.php
+++ b/src/FastNorth/PropertyMapper/Transformer/DateTime/StringToDateTime.php
@@ -2,8 +2,8 @@
 
 namespace FastNorth\PropertyMapper\Transformer\DateTime;
 
-use FastNorth\PropertyMapper\Transformer\TransformerInterface;
 use DateTime;
+use FastNorth\PropertyMapper\Transformer\TransformerInterface;
 
 /**
  * StringToDateTime

--- a/src/FastNorth/PropertyMapper/Transformer/TransformerInterface.php
+++ b/src/FastNorth/PropertyMapper/Transformer/TransformerInterface.php
@@ -12,7 +12,7 @@ interface TransformerInterface
     /**
      * Transform a value
      *
-     * @param mixed $value
+     * @param mixed        $value
      * @param array|object $context the "from" side of the mapping
      */
     public function transform($value, $context);
@@ -20,7 +20,7 @@ interface TransformerInterface
     /**
      * Reverse-transform a value
      *
-     * @param mixed $value
+     * @param mixed        $value
      * @param array|object $context the "to" side of the mapping
      */
     public function reverse($value, $context);

--- a/tests/Stubs/Embed.php
+++ b/tests/Stubs/Embed.php
@@ -39,4 +39,3 @@ class Embed
         return $this;
     }
 }
-

--- a/tests/Unit/EmbedTest.php
+++ b/tests/Unit/EmbedTest.php
@@ -22,7 +22,7 @@ class EmbedTest extends TestCase
         $to = new Stubs\Embed;
 
         $embedMap = (new Map)->map('[foo]', 'mappedFoo');
-        $map = (new Map)->embed('embedded', $embedMap, new CallbackFactory(function() {
+        $map = (new Map)->embed('embedded', $embedMap, new CallbackFactory(function () {
             return new Stubs\To;
         }));
 
@@ -45,7 +45,7 @@ class EmbedTest extends TestCase
             (new Map)->embed(
                 'embedded',
                 (new Map)->map('[foo]', 'mappedFoo'),
-                new CallbackFactory(function() {
+                new CallbackFactory(function () {
                     return new Stubs\To;
                 })
             )
@@ -54,4 +54,3 @@ class EmbedTest extends TestCase
         $this->assertEquals('value from mapped foo', $from['foo']);
     }
 }
-

--- a/tests/Unit/EmbeddedCollectionsTest.php
+++ b/tests/Unit/EmbeddedCollectionsTest.php
@@ -33,10 +33,10 @@ class EmbeddedCollectionsTest extends TestCase
                 'mappedChildren',
                 (new Map)->map('foo', 'mappedFoo'),
                 new CallbackFactory(
-                    function($value) {
+                    function ($value) {
                         return new Stubs\To;
                     },
-                    function($value) {
+                    function ($value) {
                         return [];
                     }
                 )
@@ -48,7 +48,7 @@ class EmbeddedCollectionsTest extends TestCase
 
         $this->assertCount(3, $to->getMappedChildren());
         $count = 0;
-        foreach($to->getMappedChildren() as $child) {
+        foreach ($to->getMappedChildren() as $child) {
             $this->assertInstanceOf(Stubs\To::class, $child);
             $this->assertEquals(sprintf('foo child %d', $count++), $child->getMappedFoo());
         }
@@ -72,10 +72,10 @@ class EmbeddedCollectionsTest extends TestCase
                 'mappedChildren',
                 (new Map)->map('[foo]', 'foo'), // Maps from array to property
                 new CallbackFactory(
-                    function($value) {
+                    function ($value) {
                         return new Stubs\To;
                     },
-                    function($value) {
+                    function ($value) {
                         return [];
                     }
                 )
@@ -89,7 +89,7 @@ class EmbeddedCollectionsTest extends TestCase
 
         $this->assertCount(3, $from->getChildren());
         $count = 0;
-        foreach($from->getChildren() as $child) {
+        foreach ($from->getChildren() as $child) {
             $this->assertTrue(is_array($child));
             $this->assertEquals(sprintf('foo child %d', $count++), $child['foo']);
         }

--- a/tests/Unit/MapperTest.php
+++ b/tests/Unit/MapperTest.php
@@ -109,5 +109,60 @@ class MapperTest extends TestCase
 
         $this->assertEquals('value for foo', $to->getMappedFoo());
     }
+
+    /** @test */
+    public function itSetsDefaultProperly()
+    {
+        $map = new Map;
+        $map
+            ->map('[leftA]', '[rightA]')
+            ->map('[leftB]', '[rightB]', null, 'default')
+            ->map('[leftC]', '[rightC]');
+
+        $from = [
+            'leftA' => 'value for a',
+            'leftC' => 'value for c',
+        ];
+
+        $to = [];
+
+        $mapper = new Mapper;
+
+        $mapper->process($from, $to, $map);
+
+
+        $this->assertEquals('value for a', $to['rightA']);
+        $this->assertEquals('default', $to['rightB']);
+        $this->assertEquals('value for c', $to['rightC']);
+    }
+
+    /** @test */
+    public function itSetsDefaultsProperlyOnReverse()
+    {
+        $map = new Map;
+        $map
+            ->map('leftA', 'rightA')
+            ->map('leftB', 'rightB')
+            ->map('leftC', 'rightC', null, 'default');
+
+        $from = (object) [
+            'leftA' => null,
+            'leftB' => null,
+            'leftC' => null,
+        ];
+
+        $to = (object) [
+            'rightA' => 'value for a',
+            'rightB' => 'value for b',
+        ];
+
+        $mapper = new Mapper;
+
+        $mapper->reverse($from, $to, $map);
+
+        $this->assertEquals('value for a', $from->leftA);
+        $this->assertEquals('value for b', $from->leftB);
+        $this->assertEquals('default', $from->leftC);
+    }
 }
 

--- a/tests/Unit/MapperTest.php
+++ b/tests/Unit/MapperTest.php
@@ -165,4 +165,3 @@ class MapperTest extends TestCase
         $this->assertEquals('default', $from->leftC);
     }
 }
-


### PR DESCRIPTION
It's currently throwing an exception when processing a link where the `from` value doesn't exist. This PR allows the ability to set a default so it's always mapped properly even when the expected value isn't present (some API's return data conditionally).

This also works the other way when reversing (if the `to` value doesn't exist)

This may introduce a BC break because the processed links will always include the fields from the included map. There is also a change to the `PropertyAccessor` constructor that enables the `throwExceptionsOnInvalidIndex` flag. This allows for the default to be set when mapping arrays with missing indexes (previously it would just set null).

There is also a little bit of code cleanup in this PR.