### PR TITLE
chore: add composer type library to property-mapper

### DIFF
--- a/composer-alias/composer.json
+++ b/composer-alias/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "fastnorth/property-mapper-new",
+    "type": "library",
     "description": "Transforms data structures",
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "fastnorth/property-mapper",
+    "type": "library",
     "description": "Transforms data structures",
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Adds `"type": "library"` to `composer.json` (metadata-only change)

## Why
Renovate and other Composer tooling use `composerJsonType` to distinguish libraries from applications. This package is consumed as a dependency by other projects.

## Test plan
- [x] No runtime or lockfile changes
- [ ] CI passes

Made with [Cursor](https://cursor.com)