### PR TITLE
fix(composer): use || for multi-version constraints

### DIFF
--- a/composer-alias/composer.json
+++ b/composer-alias/composer.json
@@ -9,11 +9,11 @@
         }
     },
     "require": {
-        "symfony/property-access": "~2.7|~3.2|~4.0|~5.0|~6.0|~7.0"
+        "symfony/property-access": "~2.7 || ~3.2 || ~4.0 || ~5.0 || ~6.0 || ~7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "symfony/var-dumper": "~2.7|~3.2|~4.0"
+        "symfony/var-dumper": "~2.7 || ~3.2 || ~4.0"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
         }
     },
     "require": {
-        "symfony/property-access": "~2.7|~3.2|~4.0|~5.0|~6.0|~7.0"
+        "symfony/property-access": "~2.7 || ~3.2 || ~4.0 || ~5.0 || ~6.0 || ~7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "symfony/var-dumper": "~2.7|~3.2|~4.0"
+        "symfony/var-dumper": "~2.7 || ~3.2 || ~4.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
## Summary
Replace single-pipe (`|`) version constraints with Composer-supported `||` OR syntax so Renovate can parse `composer.json` (fixes Dependency Dashboard "Unsupported composer value" warnings).

## Test plan
- [x] `composer validate` where applicable
- [x] Renovate Dependency Dashboard no longer warns on these constraints
